### PR TITLE
set blog post url scheme to be /:year/:month/:slug (#26)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -296,7 +296,9 @@ defaults:
       path: ""
       type: posts
     values:
+      permalink: /:year/:month/:slug
       layout: single
+      classes: wide
       author_profile: true
       read_time: true
       comments: false

--- a/_posts/2019-04-18-be-a-builder.md
+++ b/_posts/2019-04-18-be-a-builder.md
@@ -1,13 +1,10 @@
 ---
 title:  "Be a Builder: Help Improve Wellbeing, Freedom and Society!"
-permalink: /general/be-a-builder/
 excerpt: "We proudly announce to you the Mission and Vision we have adopted at the Humane Tech Community. We are building Pyramids again!"
 header:
   teaser: /assets/images/blog/be-a-builder/humane-tech-community-overview.png
   og_image: /assets/images/blog/be-a-builder/humane-tech-community-overview.png
 last_modified_at: 2019-04-18T07+02:00
-layout: single
-classes: wide
 comments: true
 
 # See: https://github.com/humanetech-community/community-hub/issues/48

--- a/_posts/2019-04-19-position-statement.md
+++ b/_posts/2019-04-19-position-statement.md
@@ -1,13 +1,10 @@
 ---
 title:  "Humane Tech Community Position Statement"
-permalink: /general/position-statement/
 excerpt: "With our mindset of optimism, positivity and solution focus we at Humane Tech Community are uniquely focused to tackle the Harms of Technology."
 header:
   teaser: /assets/images/blog/position-statement/humanetech-community-open-canvas-summary.png
   og_image: /assets/images/blog/position-statement/humanetech-community-open-canvas-summary.png
 last_modified_at: 2019-04-18T07+02:00
-layout: single
-classes: wide
 comments: true
 
 # See: https://github.com/humanetech-community/community-hub/issues/48

--- a/_posts/2019-04-20-small-is-huge.md
+++ b/_posts/2019-04-20-small-is-huge.md
@@ -1,6 +1,5 @@
 ---
 title:  "Small is Huge!"
-permalink: "/general/small-is-huge/"
 excerpt: "I am just a small guy, I realize it and have come to appreciate that. Yes, I can even say that I crave to become smaller and smaller, until I am tiny."
 header:
   image: /assets/images/blog/small-is-huge/small-meteorite-from-mars.jpg
@@ -8,8 +7,6 @@ header:
   og_image: /assets/images/blog/small-is-huge/small-meteorite-from-mars-ogimage.jpg
 author: Arnold Schrijver
 last_modified_at: 2019-04-20T09+02:00
-layout: single
-classes: wide
 
 # See: https://github.com/humanetech-community/community-hub/issues/48
 # 

--- a/_posts/2019-04-22-social-media-and-self-perception.md
+++ b/_posts/2019-04-22-social-media-and-self-perception.md
@@ -1,11 +1,8 @@
 ---
 title:  "Social Media and Self Perception : A Personal Reflection"
-permalink: /wellbeing/children and teens/social-media-and-self-perception/
 excerpt: "I accepted that I was human, imperfect, and that it was okay to not look like my ‘best’ self all the time."
 author: Siddhi Upadhyaya
 last_modified_at: 2019-04-22T12+02:00
-layout: single
-classes: wide
 
 # See: https://github.com/humanetech-community/community-hub/issues/48
 # 

--- a/_posts/2019-04-23-d-day-at-cht.md
+++ b/_posts/2019-04-23-d-day-at-cht.md
@@ -1,13 +1,10 @@
 ---
 title:  "Today is D-Day at The Center for Humane Technology: &quot;A New Agenda for Tech&quot; Livestream"
-permalink: /general/d-day-at-cht/
 excerpt: "April 23rd is a very special day. After a full year operating under the radar, preparing, The Center for Humane Technology will set &quot;A New Agenda for Tech&quot;!"
 header:
   teaser: /assets/images/blog/d-day-at-cht/humanetech-cht-livestream-announcement.jpg
   og_image: /assets/images/blog/d-day-at-cht/humanetech-cht-livestream-announcement.jpg
 last_modified_at: 2019-04-23T12+02:00
-layout: single
-classes: wide
 comments: true
 
 # See: https://github.com/humanetech-community/community-hub/issues/48


### PR DESCRIPTION
Right now I have it as /:year/:month/:slug as mentioned in #26, but this is easily customizable. See [here](https://jekyllrb.com/docs/permalinks/#placeholders) for a full list of variables we can use (mostly just other formatting options for date/time, plus title and categories)