### PR TITLE
add a step by step guide for contributing blog posts and other content (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,10 @@ This is the project from where the community website is developed and maintained
 
 
 ## Contributing
-Check out the [Open Source Guide](https://opensource.guide/)
+Check out the [Open Source Guide](https://opensource.guide/) for general information about contributing to open source.
 
-### Getting started
-1) Fork this repository, then clone your fork to make changes on your local machine. See [here](https://help.github.com/en/articles/fork-a-repo) for help on forking and keeping your fork synced.
+### Contributing Code
+If you'd like to help build the website itself, [click here](contributing-code) to read about how to get started.
 
-2) Install bundler and jekyll gems.
-
-        gem install bundler jekyll
-
-    If this command fails because you do not have ruby on your machine, follow the [instructions to install ruby](https://www.ruby-lang.org/en/documentation/installation/).
-
-3) Install dependencies for this project.
-
-        bundle install
-
-4) Start jekyll to build the site and make it available on a local server. You should be able to see it running at http://localhost:4000
-
-        bundle exec jekyll serve
-
-5) Once your changes are ready, you'll make a pull request (PR) to have your changes reviewed by one of the maintainers who can merge the changes to the production website.
-
-6) Check out the [issues tab](https://github.com/humanetech-community/community-hub/issues) for open tickets you might be able to help with, especially if there are any with the ![](https://img.shields.io/badge/-good%20first%20issue-blueviolet.svg) tag!
-
-
-### Docs / Resources
-- jekyll docs: https://jekyllrb.com/docs/
-- Minimal Mistakes jekyll theme: https://mmistakes.github.io/minimal-mistakes/
+### Contributing Content
+If you'd like to write a blog post, share research and other resources, or contribute other content to the site, [click here](contributing-content) to find out how.

--- a/contributing-code.md
+++ b/contributing-code.md
@@ -1,0 +1,32 @@
+# Contributing code
+### Getting started
+1) Fork this repository, then clone your fork to make changes on your local machine. See [here](https://help.github.com/en/articles/fork-a-repo) for help on forking and keeping your fork synced.
+
+2) Install bundler and jekyll gems.
+
+        gem install bundler jekyll
+
+    If this command fails because you do not have ruby on your machine, follow the [instructions to install ruby](https://www.ruby-lang.org/en/documentation/installation/).
+
+3) Install dependencies for this project.
+
+        bundle install
+
+4) Start jekyll to build the site and make it available on a local server. You should be able to see it running at http://localhost:4000
+
+        bundle exec jekyll serve
+
+5) Once your changes are ready, you'll make a pull request (PR) to have your changes reviewed by one of the maintainers who can merge the changes to the production website.
+
+6) Check out the [issues tab](https://github.com/humanetech-community/community-hub/issues) for open tickets you might be able to help with, especially if there are any with the ![](https://img.shields.io/badge/-good%20first%20issue-blueviolet.svg) tag!
+
+
+### Docs / Resources
+- The community hub is a static site built with [jekyll](https://jekyllrb.com/). If you're new to jekyll, we recommend checking out the [docs](https://jekyllrb.com/docs), in particular the [tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/).
+
+- On top of jekyll, we also use a theme called [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) which provides a lot of useful functionality.
+
+
+### Tips / Tricks
+- remember that any changes to `_config.yml` will require you to restart jekyll in order to take effect!
+

--- a/contributing-content.md
+++ b/contributing-content.md
@@ -1,0 +1,27 @@
+# Contributing content
+### Blog posts
+The website uses the same Markdown syntax that the forum uses. You can write your text in a new forum topic and we will help you along. Here’s the procedure:
+
+1) Create a new topic in the [Awareness program category](https://community.humanetech.com/c/focus/awareness-program).
+
+1) Use as title “Blog post: [Your proposed blog title]”.
+
+1) Write a short summary of the subject and other things you want to address in the blog post.
+
+1) Submit your post. It will appear publicly after a Moderator has approved (which we will do).
+
+1) Optionally some discussion ensues on the topic with tips and feedback to refine the article
+
+1) When ready, write the full blog post!
+    - Feel free to use any of the formatting and Markdown syntax available on the forum. Use this [Markdown tutorial](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to see other markdown syntax you can use for formatting.
+    - Include as many images as you like (but note licensing issues, and where you got them from)
+
+1) When you're finished, we will help you to transfer the text to the website! 
+
+All your work is attributed to you and has your name to it (unless you want to stay anonymous, of course). You are the copyright owner (the license is [CC-BY](https://creativecommons.org/licenses/by/4.0/)).
+
+
+### Other content
+If you're looking for content to contribute, check out the [issues tab]() for tickets with the ![](https://img.shields.io/badge/-content%20needed-blue.svg) tag!
+
+Once you find content you'd like to contribute, create a new topic in the most relevant category on the [forum](https://community.humanetech.com/) to share it, and we will help transfer it to the site. If you're unsure which category it belongs in, create it in [feedback](https://community.humanetech.com/c/central/feedback).


### PR DESCRIPTION
I copied most of the instructions for contributing content from [here](https://community.humanetech.com/t/help-build-our-community-hub-and-publish-your-own-blog-entries-now/3824), but made some small changes so let me know if I got it right!

With this PR, I am also proposing a ![](https://img.shields.io/badge/-content%20needed-blue.svg) issue label, to make it easier for non-technical people to help contribute content. Open to suggestions!