### PR TITLE
Add embed code for Meetup Chapters map (#76)

### DIFF
--- a/_activities/00-activities-root/03-meetup-chapters.md
+++ b/_activities/00-activities-root/03-meetup-chapters.md
@@ -27,6 +27,10 @@ custom_pagination:
 | San Francisco | [@ferj](https://community.humanetech.com/u/ferj/summary), [@willmattei](https://community.humanetech.com/u/willmattei/summary) | [**Meetup.com**](https://www.meetup.com/Humane-Tech-SF/), [newsletter](http://www.humanetechsf.com/), [FB event page](https://www.facebook.com/events/311234492803190) |
 | Seattle | [@joseadna](https://community.humanetech.com/u/joseadna/summary) | [**Meetup.com**](https://www.meetup.com/Humane-Tech-Seattle-Puget-Sound/), [forum discussion](https://community.humanetech.com/t/seattle-chapter-meetups/872) | 
 
+<!-- Embed chapters map: -->
+<iframe src="https://vbernardes.github.io/htc-map/?show=chapters" width="100%" height="400" allowfullscreen="true" frameborder="0">
+<p><a href="https://vbernardes.github.io/htc-map/?show=chapters" target="_blank">See the Humane Tech Community Map!</a></p>
+</iframe>
 
 ## Other Humane Technology-related Meetup Groups
 


### PR DESCRIPTION
Add world map showing HTC Meetup Chapters to the Meetup Chapters page, as suggested in #76.