### PR TITLE
Wrap recent posts around a div with grid__wrapper class

### DIFF
--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -154,7 +154,7 @@
 
     &:nth-child(2n + 2) {
       clear: none;
-      margin-left: gutter(of 10);
+      margin-left: gutter(1 of 10);
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -67,9 +67,11 @@ under_construction:
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
 
-{% for post in site.posts limit:2 %}
-  {% include archive-single.html type="grid" %}
-{% endfor %}
+<div class="grid__wrapper">
+  {% for post in site.posts limit:4 %}
+    {% include archive-single.html type="grid" %}
+  {% endfor %}
+</div>
 
 {% include feature_row id="feature_quote2" type="center" %}
 


### PR DESCRIPTION
So, looking at both the main page and a blog post page, I noticed that the problem was that the first one missed a wrapper around the articles.
Once I addressed this issue in `index.html`, everything started to make sense again 😉 
```html
<div class="grid__wrapper">
  {% for post in site.posts limit:4 %}
    {% include archive-single.html type="grid" %}
  {% endfor %}
</div>
```